### PR TITLE
Stabilize ms.date after docs post-processing

### DIFF
--- a/azure-pipelines/common-templates/generate-module-docs-steps.yml
+++ b/azure-pipelines/common-templates/generate-module-docs-steps.yml
@@ -157,6 +157,15 @@ steps:
       filePath: scripts/CorrectRelatedLinks-AllFiles.ps1
       arguments: -GraphProfileFilter "${{ parameters.GraphProfileFilter }}" -ModuleFilter "${{ parameters.Module }}"
 
+  - task: PowerShell@2
+    displayName: 'Remove date-only documentation changes'
+    condition: and(succeeded(), eq(variables['ModuleGenerated'], 'true'))
+    inputs:
+      targetType: 'filePath'
+      pwsh: true
+      filePath: scripts/StabilizeMsDate.ps1
+      arguments: -BaseRef "$(Build.SourceVersion)"
+
   - task: AzureKeyVault@2
     displayName: "Azure Key Vault: Get GitHub App secrets"
     condition: and(succeeded(), eq(variables['ModuleGenerated'], 'true'))

--- a/scripts/GenerateMarkDown.ps1
+++ b/scripts/GenerateMarkDown.ps1
@@ -100,10 +100,6 @@ function Start-GraphHelp {
         }
     }
 
-    # Remove files whose only generated change is refreshed ms.date metadata before
-    # GenerateMarkDown creates its commit.
-    & (Join-Path $PSScriptRoot "StabilizeMsDate.ps1")
-
     git config --global user.email "GraphTooling@service.microsoft.com"
     git config --global user.name "Microsoft Graph DevX Tooling"
     git add .

--- a/scripts/GenerateMarkDown.ps1
+++ b/scripts/GenerateMarkDown.ps1
@@ -100,6 +100,10 @@ function Start-GraphHelp {
         }
     }
 
+    # Remove files whose only generated change is refreshed ms.date metadata before
+    # GenerateMarkDown creates its commit.
+    & (Join-Path $PSScriptRoot "StabilizeMsDate.ps1")
+
     git config --global user.email "GraphTooling@service.microsoft.com"
     git config --global user.name "Microsoft Graph DevX Tooling"
     git add .

--- a/scripts/StabilizeMsDate.ps1
+++ b/scripts/StabilizeMsDate.ps1
@@ -1,16 +1,25 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 #
-# Reverts files where the only change compared to HEAD is the ms.date
-# metadata line. This prevents date-only churn from inflating PR diffs.
+# Reverts files where the only change compared to the generation baseline is
+# the ms.date metadata line. This prevents date-only churn from inflating PR diffs.
+
+param(
+    [string] $BaseRef = "HEAD"
+)
 
 $ErrorActionPreference = 'Stop'
 
 Write-Host -ForegroundColor Green "-------------Stabilizing ms.date values-------------"
 
-$modifiedFiles = git diff --name-only -- '*.md'
+$null = git rev-parse --verify "$BaseRef^{commit}"
 if ($LASTEXITCODE -ne 0) {
-    Write-Error "git diff --name-only failed with exit code $LASTEXITCODE"
+    throw "Base ref '$BaseRef' does not resolve to a commit."
+}
+
+$modifiedFiles = git diff --name-only --diff-filter=M $BaseRef -- '*.md'
+if ($LASTEXITCODE -ne 0) {
+    throw "git diff --name-only failed with exit code $LASTEXITCODE"
 }
 
 $revertedCount = 0
@@ -19,27 +28,22 @@ foreach ($file in $modifiedFiles) {
     if ([string]::IsNullOrWhiteSpace($file)) { continue }
     if (-not (Test-Path $file)) { continue }
 
-    # Get the raw diff with no context, then extract only +/- content lines
-    $rawDiff = git diff --unified=0 -- $file
-    # Filter to content change lines only (skip headers, hunk markers, and
-    # special markers like "\ No newline at end of file")
-    $diffLines = $rawDiff | Where-Object {
-        ($_ -match '^\+[^+]' -or $_ -match '^\-[^-]') -and $_ -notmatch '^\\ '
+    $baselineContent = @(git show "${BaseRef}:$file")
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to read '$file' from base ref '$BaseRef'."
     }
+    $currentContent = @(Get-Content -LiteralPath $file)
 
-    # Check if all changed lines are ms.date changes
-    $allMsDate = $true
-    $hasChanges = $false
-    foreach ($line in $diffLines) {
-        $hasChanges = $true
-        if ($line -notmatch '^[+-]ms\.date: ') {
-            $allMsDate = $false
-            break
-        }
-    }
+    $baselineDates = @($baselineContent | Where-Object { $_ -match '^ms\.date: ' })
+    $currentDates = @($currentContent | Where-Object { $_ -match '^ms\.date: ' })
+    $dateChanged = (($baselineDates -join "`n") -cne ($currentDates -join "`n"))
 
-    if ($hasChanges -and $allMsDate) {
-        git checkout -- $file
+    $baselineWithoutDates = @($baselineContent | Where-Object { $_ -notmatch '^ms\.date: ' })
+    $currentWithoutDates = @($currentContent | Where-Object { $_ -notmatch '^ms\.date: ' })
+    $onlyMsDateChanged = (($baselineWithoutDates -join "`n") -ceq ($currentWithoutDates -join "`n"))
+
+    if ($dateChanged -and $onlyMsDateChanged) {
+        git checkout $BaseRef -- $file
         if ($LASTEXITCODE -ne 0) {
             Write-Warning "Failed to revert $file (exit code $LASTEXITCODE)"
         } else {


### PR DESCRIPTION
## Summary
- run ms.date stabilization after all documentation post-processing steps
- compare final generated docs against the pipeline source commit, including earlier generated commits
- restore only modified files whose sole cumulative change is the ms.date metadata value
- preserve genuine content changes, added files, and case-only edits

## Why
PR #1040 showed that stabilizing immediately after markdown generation was too early. At that point files also contained transient generated content changes, so they were not classified as date-only. Later post-processing restored the content but left the refreshed dates in the final PR.

## Validation
- simulated generation and post-processing commits
- confirmed date-only files are restored
- confirmed genuine dashed-line changes, case-only edits, and added files remain